### PR TITLE
Add more HintPaths for OTAPI

### DIFF
--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -74,7 +74,9 @@
     </Reference>
     <Reference Include="OTAPI, Version=1.3.4.4, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll</HintPath>
+      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll</HintPath>
+      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll</HintPath>
+      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\$(Configuration)\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\$(Configuration)\OTAPI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
This will help msbuild to find missing libraries when create release
with `/p:Configuration=Release`.

With this patch, the searching order will be:
  - If OTAPI with same configuration found, use that.
  - Else if OTAPI with Release configuration found, use that.
  - Else use OTAPI with Debug configuration.

This will fix the issue #1480